### PR TITLE
fix: disable optimizeCss to resolve critters dependency error

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,13 @@
 # Implementation Plan
 
+## Blockers
+### Build Dependencies
+- [x] Next.js runtime dependency 'critters' not found
+  - Error: Could not resolve "critters" in next-server/pages.runtime.prod.js
+  - Impact: Blocks production build process
+  - Resolution: Disabled experimental optimizeCss feature in next.config.mjs
+  - Status: Resolved, build passing
+
 ## Architecture Overview
 - NextJS application deployed on Cloudflare Workers via OpenNext
 - Vector storage using Cloudflare Vectorize for blog content and embeddings

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,7 @@ const nextConfig = {
   swcMinify: true,
   experimental: {
     serverActions: true,
+    optimizeCss: false,
   },
 };
 


### PR DESCRIPTION
This PR resolves the build error related to the missing critters dependency by explicitly disabling the experimental optimizeCss feature in next.config.mjs.

## Changes
- Disabled optimizeCss in next.config.mjs experimental options
- Updated TODO.md to document resolution
- Prevents build error: Could not resolve 'critters'

## Context
The critters dependency is only required when Next.js's experimental CSS optimization feature is enabled. By explicitly disabling this feature, we resolve the build error without adding unnecessary dependencies.

## Verification
- Build now passes successfully
- No changes to runtime functionality
- Warnings about serverActions being available by default are unrelated and can be addressed separately if needed

Link to Devin run: https://app.devin.ai/sessions/d6df5ec576ee41b78050485bf9c8112c